### PR TITLE
fixing not exported chemical synonyms with typeTitle=synonym

### DIFF
--- a/apps/api/logic/xlsx_export.py
+++ b/apps/api/logic/xlsx_export.py
@@ -265,8 +265,14 @@ def process_chemicals(chemicals, nf_id):
                     for synonym in chem_synonyms
                     if synonym["typeTitle"] == "trade name"
                 ]
+                chemical_synonym_names = [
+                    synonym
+                    for synonym in chem_synonyms
+                    if synonym["typeTitle"] == "synonym"
+                ]
                 chemical["common names"] = serialize_synonyms(chemical_common_names)
                 chemical["trade names"] = serialize_synonyms(chemical_trade_names)
+                chemical["synonyms"] = serialize_synonyms(chemical_synonym_names)
             else:
                 chemical["synonyms"] = serialize_synonyms(chem_synonyms)
 


### PR DESCRIPTION
I have noticed that fetched data (Chemical - Chemical Synonym for Novel Food with NFCode=NF 2019/1457) are not being exported:

<img width="912" alt="Screenshot 2024-12-16 at 18 43 13" src="https://github.com/user-attachments/assets/de876d70-a09b-4366-9c61-98f26da9bad2" />

<img width="673" alt="Screenshot 2024-12-16 at 18 50 51" src="https://github.com/user-attachments/assets/091403ad-7270-427e-bda0-8f07ae753b6a" />

I have looked whether the exporting function `create_export` is getting the data, and indeed it does:
<img width="717" alt="Screenshot 2024-12-16 at 18 49 42" src="https://github.com/user-attachments/assets/434409b0-aa18-46c8-b610-f690ba90a431" />

Therefore I concluded that there might be bug in the exporting code?  In this pull request I have drafted code changes which fixes the issue. However I am not sure whether by making this changes I could have destroyed some other parts of the code responsible for export and/or whether there could be bugs of similar design in other parts of this exporting code.

I would like to kindly ask you @xdxdhh  for your review, for which I thank you very much in advance! :)